### PR TITLE
fix(hanko): align hanko-wrapped modal corners with $theme-border-radius

### DIFF
--- a/assets/scss/hanko.scss
+++ b/assets/scss/hanko.scss
@@ -91,6 +91,11 @@ hanko-auth::part(container), hanko-dialog::part(container), hanko-login::part(co
     border-radius: $theme-border-radius;
 }
 
+.modal:has(hanko-auth, hanko-dialog, hanko-login, hanko-profile) {
+    --#{$prefix}modal-border-radius: #{$theme-border-radius};
+    --#{$prefix}modal-inner-border-radius: #{$theme-border-radius};
+}
+
 .auth-placeholder {
     min-height: 400px;
 }


### PR DESCRIPTION
Bootstrap modals wrapping Hanko web components used the default --bs-modal-border-radius (border-radius-lg), which didn't follow the theme's $theme-border-radius. Override the modal CSS custom properties on any .modal containing a Hanko element so corners match the theme.