### PR TITLE
fix: hinode v3.7 compat (drop dead login scripts type, declare hanko-elements external)

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -8,6 +8,11 @@
         login-redirect = ""
         logout-redirect = ""
         timeout-redirect = ""
+
+        # esbuild externals for this module's bundled scripts. hanko-elements.min.mjs
+        # is a real static file (mounted from dist/) that the browser resolves at
+        # runtime; esbuild must leave the self-import in hanko.mjs alone.
+        externals = ["/js/hanko-elements.min.mjs"]
     # [modules.hanko.csp]
     #     connect-src = [
     #         "" # include your endpoint here when using CSP

--- a/layouts/baseof.login.html
+++ b/layouts/baseof.login.html
@@ -13,7 +13,6 @@
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
     <head>
         {{- partial "footer/scripts.html" (dict "page" . "type" "critical") -}}
-        {{- partial "footer/scripts.html" (dict "page" . "type" "functional") -}}
         {{ block "head" . }}{{ end -}}
     </head>
 


### PR DESCRIPTION
1) baseof.login.html passed type=functional to footer/scripts.html — an
invalid scripts type that was a silent no-op pre-v3.7 but is now rejected
by mod-utils/v6's tightened Args engine, breaking the /login build.
2) Declare /js/hanko-elements.min.mjs as an esbuild external so Hinode
v3.7's bundlev3 leaves hanko.mjs's runtime self-import alone.
