### PR TITLE
fix: pass page context to the login logo image partial

### DIFF
--- a/layouts/login.html
+++ b/layouts/login.html
@@ -8,7 +8,7 @@
             {{ $logo := "" }}
             {{ with site.Params.navigation.logo }}
                 {{ $height := index site.Params.navigation "logo-height" | default 30 }}
-                {{ partial "assets/image.html" (dict "src" . "loading" "eager" "title" site.Title "image-height" $height "class" "pt-5") }}
+                {{ partial "assets/image.html" (dict "page" $ "src" . "loading" "eager" "title" site.Title "image-height" $height "class" "pt-5") }}
             {{ end }}
             <div id="auth-placeholder" class="d-flex justify-content-center align-items-center auth-placeholder" data-auth-tag="{{ $tagName }}">
                 {{ if $authenticate }}<hanko-auth />{{ else }}<hanko-login />{{ end }}


### PR DESCRIPTION
## Summary

The login layout calls `assets/image.html` without the `page` argument, tripping Hinode's `warn-missing-page-argument` fallback on every login page render.

Verified in a tokened portal build wired to this branch via a local replace: the warning disappears from the consuming site build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)